### PR TITLE
fix: FCM Message Payload 수정

### DIFF
--- a/src/modules/messageFactory.ts
+++ b/src/modules/messageFactory.ts
@@ -27,11 +27,9 @@ type ResponseFCMMessage = {
 };
 
 type FCMMessage = {
-  notification: {
+  data: {
     title: string;
     content: string;
-  };
-  data?: {
     webLink?: string;
     deepLink?: string;
   };
@@ -72,18 +70,18 @@ const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
 const fcmMessage = (dto: MessageFactoryDTO): ResponseFCMMessage => {
   const { title, content, webLink, deepLink } = dto;
   const message: FCMMessage = {
-    notification: {
+    data: {
       title,
       content,
     },
   };
 
   if (deepLink !== undefined) {
-    message.data = { deepLink };
+    message.data.deepLink = deepLink;
   }
 
   if (webLink !== undefined) {
-    message.data = { ...(message.data || {}), webLink };
+    message.data.webLink = webLink;
   }
   return { default: DEFAULT, GCM: JSON.stringify(message) };
 };


### PR DESCRIPTION
FCM message Payload를 수정했습니다.


AS-IS
```
{
  "GCM": "{\"notification\": { \"body\": \"Sample message for Android or iOS endpoints\", \"title\":\"TitleTest\" },\"data\":{\"time_to_live\": 3600,\"collapse_key\":\"deals\"}}"
}
                    
```
TO-BE
```
{ 
  "GCM": "{\"data\":{\"title\":\"솝트 짱\" , \"content\":\"알림 티에프 짱\", \"webLink\":\"www.amazon.com\"}}",
}            
```