### PR TITLE
fix: 단일 푸쉬 토큰 선정 방식 변경

### DIFF
--- a/src/modules/tokenFactory.ts
+++ b/src/modules/tokenFactory.ts
@@ -150,8 +150,6 @@ const queryTokenByUserId = async (userId: string): Promise<QueryCommandOutput> =
       ':pk': { S: `u#${userId}` },
       ':sk': { S: 'd#' },
     },
-
-    Limit: 1,
   });
   return await ddbClient.send(command);
 };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -98,7 +98,6 @@ const getUserByTokenId = async (deviceToken: string): Promise<DeviceTokenEntity 
 const findTokenByUserIds = async (userIds: string[]): Promise<UserTokenEntity[]> => {
   const tokens = await Promise.all(userIds.flatMap(async (userId) => getTokenByUserId(userId)));
   const result = tokens.flat();
-  console.log(result);
   return result.filter((user: UserTokenEntity | []): user is UserTokenEntity => user !== null);
 };
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -37,7 +37,7 @@ function isTokenUserEntity(queryCommandOutputItems: Record<string, AttributeValu
   return true;
 }
 
-const getTokenByUserId = async (userId: string): Promise<UserTokenEntity[] | []> => {
+const getTokenByUserId = async (userId: string): Promise<UserTokenEntity[]> => {
   const queryCommandOutput = await tokenFactory.queryTokenByUserId(userId);
 
   if (queryCommandOutput.Items === undefined) {
@@ -96,9 +96,9 @@ const getUserByTokenId = async (deviceToken: string): Promise<DeviceTokenEntity 
 };
 
 const findTokenByUserIds = async (userIds: string[]): Promise<UserTokenEntity[]> => {
-  const tokens = await Promise.all(userIds.flatMap(async (userId) => getTokenByUserId(userId)));
+  const tokens = await Promise.all(userIds.map(async (userId) => getTokenByUserId(userId)));
   const result = tokens.flat();
-  return result.filter((user: UserTokenEntity | []): user is UserTokenEntity => user !== null);
+  return result.filter((user: UserTokenEntity): user is UserTokenEntity => user !== null);
 };
 
 const findUserByTokenIds = async (deviceTokens: string[]): Promise<DeviceTokenEntity[]> => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2019",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true


### PR DESCRIPTION
- 단일 푸쉬 전송시 유저의 토큰중 1개를 가져오는 로직 -> 유저의 모든 토큰을 가져오는 로직으로 변경하였습니다.