### PR TITLE
Fix/add id in payload

### DIFF
--- a/src/modules/messageFactory.ts
+++ b/src/modules/messageFactory.ts
@@ -86,7 +86,6 @@ const fcmMessage = (dto: MessageFactoryDTO): ResponseFCMMessage => {
   return { default: DEFAULT, GCM: JSON.stringify(message) };
 };
 
-//todo dev prod 나눠서 보내기
 const allMessage = (dto: MessageFactoryDTO): AllTopicMessage => {
   return {
     default: DEFAULT,

--- a/src/modules/messageFactory.ts
+++ b/src/modules/messageFactory.ts
@@ -8,6 +8,7 @@ type APNsMessage = {
     };
   };
   category: Category;
+  id: string;
   webLink?: string;
   deepLink?: string;
 };
@@ -27,6 +28,7 @@ type FCMMessage = {
     title: string;
     content: string;
     category: Category;
+    id: string;
     webLink?: string;
     deepLink?: string;
   };
@@ -41,7 +43,7 @@ const DEFAULT =
   'This is the default message which must be present when publishing a message to a topic. The default message will only be used if a message is not present for one of the notification platforms.';
 
 const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
-  const { title, content, category, webLink, deepLink } = dto;
+  const { title, content, category, webLink, deepLink, id } = dto;
   const message: APNsMessage = {
     aps: {
       alert: {
@@ -49,7 +51,8 @@ const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
         body: content,
       },
     },
-    category: category,
+    category,
+    id,
   };
 
   if (deepLink !== undefined) {
@@ -63,9 +66,10 @@ const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
 };
 
 const fcmMessage = (dto: MessageFactoryDTO): ResponseFCMMessage => {
-  const { title, content, category, webLink, deepLink } = dto;
+  const { title, content, category, webLink, deepLink, id } = dto;
   const message: FCMMessage = {
     data: {
+      id,
       title,
       content,
       category,

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -46,6 +46,7 @@ const pushArn = async (dto: PushDTO) => {
     category: dto.category,
     deepLink: dto.deepLink,
     webLink: dto.webLink,
+    id: dto.id,
   });
   const endpointArn = dto.endpointArn;
   return await push(endpointArn, message);
@@ -59,6 +60,7 @@ const pushFcm = async (dto: PushDTO): Promise<ResponsePushNotification | null> =
     category: dto.category,
     deepLink: dto.deepLink,
     webLink: dto.webLink,
+    id: dto.id,
   });
   const endpointArn = dto.endpointArn;
   return await push(endpointArn, message);
@@ -96,6 +98,7 @@ const platformPush = async (dto: {
 
 const pushAll = async (dto: PushMessageDTO): Promise<ResponsePushNotification | null> => {
   const message = messageFactory.createNewMessage({
+    id: dto.id,
     topic: PushTopic.All,
     title: dto.title,
     content: dto.content,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,7 @@ interface PushSuccessMessageDTO {
 
 interface MessageFactoryDTO {
   topic: PushTopic;
+  id: string;
   title: string;
   content: string;
   category: Category;


### PR DESCRIPTION
## 변경사항
-  id가 sns payload 누락... 실제 payload까지 도달하지 못하고 있었습니다.  
- 안쓰는 주석도 하나 날렸어요!

##  추가적인 고민이 있습니다.
- PushPayload 인터페이스에 **category필드**는 Push-notification의 공통 인터페이스가 아니라고 생각이 드는데 payload에서 제외시키는건 어떨까요? 제 기억으로는 특정 팀에서 usecase로 푸시를 카테고리별로 구분하고 싶어서 저희가 이 필드를 추가했던걸로 기억을 해요!

그래서 제안드리는 바는.
- Category 필드 payload interface에서 제외시킨다.
- 그 대신 지금까지 푸시 서버에서 정의했던 공통 인터페이스(id, title, deeplink 등)는 제외하고 푸시 서버를 사용하는 클라이언트들이 push에 보낼 기타 payload들을 object 타입으로 전달 할 수 있게 제공한다.
- 또는 deepLink의 query string으로 사용할 수 있도록 제안드린다 (expiredAt처럼)

한번 더 정리하자면 이렇습니다.

<img width="968" alt="image" src="https://github.com/sopt-makers/sopt-push-notification/assets/40652160/7fd6ff6b-9f41-4658-b6d4-52e9ffa63f4b">
또는
deepLink 뒤에 queryString 사용하기

