### PR TITLE
[HOTFIX] 버전 충돌 오류로 이전 버전으로 framework 버전 되돌림

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,6 @@
 service: sopt-push-notification
 
-frameworkVersion: '4.4.19'
+frameworkVersion: '3'
 
 useDotenv: true
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -294,6 +294,7 @@ const eventBridgeHandler = async (event: EventBridgeEvent<string, any>) => {
 };
 
 const apiGateWayHandler = async (event: APIGatewayProxyEvent) => {
+  console.log('apiGatewayHandler event', JSON.stringify(event));
   if (event.body === null || event.headers.action === undefined) {
     return response(400, status.success(statusCode.BAD_REQUEST, responseMessage.INVALID_REQUEST));
   }


### PR DESCRIPTION
# 관련 이슈
Resolved: #32 

# 구현내용

- 버전 충돌 오류가 발생해서 framework 버전을 3(이전버전)으로 변경했습니다
- 로그 확인을 위해 gateway handler에도 log를 기록하도록 추가했습니다. (개발에 활용) 