### PR TITLE
[FIX] dayjs 기본 timezone('Asia/Seoul')로 변경

### DIFF
--- a/src/modules/logFactory.ts
+++ b/src/modules/logFactory.ts
@@ -1,5 +1,5 @@
 import { DynamoDBClient, PutItemCommand, PutItemCommandOutput } from '@aws-sdk/client-dynamodb';
-import dayjs from 'dayjs';
+import dayjs from './../utils/dayjsWrapper';
 import { v4 as uuid } from 'uuid';
 import { Actions, Category, Entity, NotificationStatus, NotificationType, Platform, Services } from '../types';
 

--- a/src/modules/messageFactory.ts
+++ b/src/modules/messageFactory.ts
@@ -1,5 +1,5 @@
 import { Category, MessageFactoryDTO } from '../types';
-import dayjs from 'dayjs';
+import dayjs from './../utils/dayjsWrapper';
 
 type APNsMessage = {
   aps: {
@@ -48,14 +48,13 @@ const DEFAULT =
 const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
   const { title, content, category, webLink, deepLink, id } = dto;
   const now = dayjs();
-  const sendAt = now.format("YYYY-MM-DD HH:mm:ss");
+  const sendAt = now.format('YYYY-MM-DD HH:mm:ss');
   const message: APNsMessage = {
     aps: {
       alert: {
         title,
         body: content,
       },
-
     },
     category,
     id,
@@ -75,7 +74,7 @@ const apnsMessage = (dto: MessageFactoryDTO): ResponseApnsMessage => {
 const fcmMessage = (dto: MessageFactoryDTO): ResponseFCMMessage => {
   const { title, content, category, webLink, deepLink, id } = dto;
   const now = dayjs();
-  const sendAt = now.format("YYYY-MM-DD HH:mm:ss");
+  const sendAt = now.format('YYYY-MM-DD HH:mm:ss');
   const message: FCMMessage = {
     data: {
       id,

--- a/src/modules/tokenFactory.ts
+++ b/src/modules/tokenFactory.ts
@@ -11,7 +11,7 @@ import {
   QueryCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { Entity, Platform } from '../types';
-import dayjs from 'dayjs';
+import dayjs from './../utils/dayjsWrapper';
 
 const ddbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 

--- a/src/services/webHookService.ts
+++ b/src/services/webHookService.ts
@@ -1,6 +1,6 @@
 import { PushSuccessMessageDTO, Services, Category, WebHookType } from '../types';
 import axios from 'axios';
-import dayjs from 'dayjs';
+import dayjs from './../utils/dayjsWrapper';
 
 interface AppSuccessWebHookDTO {
   id: string;
@@ -32,7 +32,10 @@ async function appWebHook(appSuccessWebHookDTO: AppSuccessWebHookDTO): Promise<v
   }
 }
 
-async function operationScheduleSuccessWebHook(alarmId: number, dto: OperationScheduleSuccessWebHookDTO): Promise<void> {
+async function operationScheduleSuccessWebHook(
+  alarmId: number,
+  dto: OperationScheduleSuccessWebHookDTO,
+): Promise<void> {
   try {
     if (process.env.MAKERS_OPERATION_SERVER_URL === undefined) {
       throw new Error('env not defined');
@@ -81,10 +84,10 @@ const scheduleSuccessWebHook = async (alarmId: number): Promise<void> => {
 
   const sendAt = dayjs().format('YYYY-MM-DD HH:mm');
   const updateStatusWebHookDTO: OperationScheduleSuccessWebHookDTO = {
-    sendAt
+    sendAt,
   };
 
   await operationScheduleSuccessWebHook(alarmId, updateStatusWebHookDTO);
-}
+};
 
 export default { pushSuccessWebHook, scheduleSuccessWebHook };

--- a/src/utils/dayjsWrapper.ts
+++ b/src/utils/dayjsWrapper.ts
@@ -1,0 +1,15 @@
+import { Dayjs } from 'dayjs';
+import dayjsBase from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjsBase.extend(utc);
+dayjsBase.extend(timezone);
+
+const DEFAULT_TIMEZONE = 'Asia/Seoul';
+
+const dayjs: (...args: Parameters<typeof dayjsBase>) => Dayjs = (...args) => {
+  return dayjsBase(...args).tz(DEFAULT_TIMEZONE);
+};
+
+export default dayjs;


### PR DESCRIPTION
# 관련 이슈
Resolved: #38 

# 구현내용

- `dayjs`를 사용할 때 기본 timezone(`Asia/Seoul`)을 적용하도록 wrapper 함수를 작성했습니다.